### PR TITLE
fixed issue where would trigger threefold draw condition for 50-move draw

### DIFF
--- a/src/games/chess/game-manager.ts
+++ b/src/games/chess/game-manager.ts
@@ -150,7 +150,7 @@ Valid moves: ${this.game.chess.moves()      // Take all valid moves,
         // - insufficient material
         // - three fold repetition
         // Keeping this check last, guarantees everything but the 50-move rule have been checked
-        if (chess.in_draw()) {
+        if (!chess.in_threefold_repetition() && chess.in_draw()) {
             return [
                 "Draw - 50-move rule: 50 moves completed with no pawn "
               + "moved or piece captured.",


### PR DESCRIPTION
chess.in_draw() calls the threefold repetition internally which will cause it to trigger whether we wanted it to or not. Since that is only sometimes applied (can use the simplified rule) I just added a check to make sure it wasn't true so only triggers if because of 50 move rule